### PR TITLE
remove Moose::Autobox as a prereq

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,7 +12,6 @@ my $builder = Module::Build->new(
     },
     requires       => {
         'Moose'          => 0,
-        'Moose::Autobox' => '0.11',
         'Pod::Elemental' => '0.101620',
         'Pod::Weaver'    => 0,
     },

--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Pod-Weaver-Role-SectionReplacer
 
+        Removed use of Moose::Autobox
+
 1.00    Version released at 2010-09-15-09:48.
         Released rc 0.99_02 as stable.
 

--- a/lib/Pod/Weaver/Role/SectionReplacer.pm
+++ b/lib/Pod/Weaver/Role/SectionReplacer.pm
@@ -5,8 +5,8 @@ package Pod::Weaver::Role::SectionReplacer;
 use Moose::Role;
 with 'Pod::Weaver::Role::Transformer';
 
-use Moose::Autobox 0.11;
 use Pod::Elemental::Selectors -all;
+use List::Util qw(first any);
 
 our $VERSION = '1.00';
 
@@ -44,13 +44,15 @@ sub transform_document {
       $content =~ s/\s+$//;
 
       return( $command_selector->( $_[ 0 ] ) &&
-        $aliases->any() eq $content );
+        any { $_ eq $content } @$aliases );
     };
 
-  return unless $document->children->grep($named_selector)->length;
+  my $original_section = first { $named_selector->($_) } @{ $document->children };
+
+  return unless defined $original_section;
 
   #  Take the first matching section found...
-  $self->original_section($document->children->grep($named_selector)->first);
+  $self->original_section($original_section);
 
   #  ...and prune it from the document.
   my $in_node = $document->children;

--- a/t/50-weave.t
+++ b/t/50-weave.t
@@ -7,7 +7,6 @@ use lib 't/inc';
 
 use Test::More;
 use Test::Differences;
-use Moose::Autobox 0.10;
 
 use PPI;
 


### PR DESCRIPTION
Moose::Autobox has been removed from Pod::Weaver for a long time, so it's an extra prerequisite for no real benefit. It has also started throwing deprecation warnings.